### PR TITLE
Update self-references to this repository's URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qiskit-neko
 
-[![License](https://img.shields.io/github/license/Qiskit/qiskit-neko.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/github/license/mtreinish/qiskit-neko.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
 
 This repository contains integration tests for Qiskit. These tests are used
 for primarily for two purposes as backwards compatibility testing for Qiskit

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description="Integration testing for Qiskit",
     long_description=README,
     long_description_content_type="text/markdown",
-    url="https://github.com/Qiskit/qiskit-neko",
+    url="https://github.com/mtreinish/qiskit-neko",
     author="Matthew Treinish",
     author_email="mtreinish@kortar.org",
     license="Apache 2.0",
@@ -61,9 +61,9 @@ setup(
     include_package_data=True,
     python_requires=">=3.7",
     project_urls={
-        "Bug Tracker": "https://github.com/Qiskit/qiskit-neko/issues",
+        "Bug Tracker": "https://github.com/mtreinish/qiskit-neko/issues",
         "Documentation": "https://qiskit.org/documentation/",
-        "Source Code": "https://github.com/Qiskit/qiskit-neko",
+        "Source Code": "https://github.com/mtreinish/qiskit-neko",
     },
     zip_safe=False,
     entry_points={


### PR DESCRIPTION
This will, among other things, fix the license badge in the README

```
sed -i 's|Qiskit/qiskit-neko|mtreinish/qiskit-neko|' $(git ls-files)
```