### PR TITLE
Bump black version and fix CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==21.12b0
+black~=22.0
 astroid==2.9.2
 pylint==2.12.2
 Sphinx>=3.0.0


### PR DESCRIPTION
This commit bumps the black version we pin to the latest release.
Since the first release this year black is no longer in beta and
with that black has introduced a stability policy where no formatting
changes will be introduced on a major version release (which is the
year). [1] With this new policy in place we no longer need to pin to a
single version and can instead constrain the requirement to just the
major version without worrying about a new release breaking ci or local
development. This commit does that and sets the black version
requirement to be any 22.x.y release so that we'll continue to get
bugfixes moving forward without having to manually bump a pinned version.

[1] https://black.readthedocs.io/en/latest/the_black_code_style/index.html#stability-policy